### PR TITLE
fix typescript select-order typing issues

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -149,7 +149,7 @@ export interface ISelectQuery {
     where?: IWhereQuery | IWhereQuery[];
     skip?: number;
     limit?: number;
-    order?: IOrderQuery;
+    order?: IOrderQuery | IOrderQuery[];
     groupBy?: string | string[] | { [columnName: string]: [ICaseOption] };
     aggregate?: IAggregateOption;
     distinct?: boolean;

--- a/src/worker/executors/select/index.ts
+++ b/src/worker/executors/select/index.ts
@@ -59,12 +59,7 @@ export class Select extends BaseFetch {
             this.limitRecord = query.limit;
         }
         if (query.order) {
-            if(isArray(query.order)){
-                for(let order of this.query.order as IOrderQuery[]){
-                    order.idbSorting = false;
-                }
-            }
-            else if (isNotOrderQueryArray(this.query.order) && (this.query.order.case || isObject(this.query.order.by))) {
+            if (isNotOrderQueryArray(this.query.order) && (this.query.order.case || isObject(this.query.order.by))) {
                 this.query.order.idbSorting = false;
             }
             this.setLimitAndSkipEvaluationAtEnd_();

--- a/src/worker/executors/select/index.ts
+++ b/src/worker/executors/select/index.ts
@@ -2,7 +2,7 @@ import { ISelectQuery, QUERY_OPTION, IDB_MODE, API, IWhereQuery, promiseResolve 
 import { IDBUtil } from "@/worker/idbutil";
 import { QueryHelper } from "@worker/executors/query_helper";
 import { DbMeta } from "@/worker/model";
-import { isArray, isObject, getKeys, getObjectFirstKey, promiseReject, getLength } from "@/worker/utils";
+import { isArray, isObject, getKeys, getObjectFirstKey, promiseReject, getLength, isNotOrderQueryArray } from "@/worker/utils";
 import { setPushResult, setLimitAndSkipEvaluationAtEnd, removeDuplicates } from "./base_select";
 import { ThenEvaluator } from "./then_evaluator";
 import { executeWhereUndefinedLogic } from "./not_where"
@@ -13,6 +13,7 @@ import { BaseFetch } from "@executors/base_fetch";
 import { executeInLogic } from "./in";
 import { executeRegexLogic } from "./regex";
 import { executeJoinQuery } from "./join";
+import { IOrderQuery } from '../../../common/interfaces';
 
 export class Select extends BaseFetch {
     sorted = false;
@@ -58,7 +59,12 @@ export class Select extends BaseFetch {
             this.limitRecord = query.limit;
         }
         if (query.order) {
-            if (isArray(query.order) || query.order.case || isObject(query.order.by)) {
+            if(isArray(query.order)){
+                for(let order of this.query.order as IOrderQuery[]){
+                    order.idbSorting = false;
+                }
+            }
+            else if (isNotOrderQueryArray(this.query.order) && (this.query.order.case || isObject(this.query.order.by))) {
                 this.query.order.idbSorting = false;
             }
             this.setLimitAndSkipEvaluationAtEnd_();

--- a/src/worker/executors/select/not_where.ts
+++ b/src/worker/executors/select/not_where.ts
@@ -1,10 +1,10 @@
 import { Select } from "./index";
-import { LogHelper, promiseReject, getError } from "@/worker/utils";
+import { LogHelper, promiseReject, getError, isNotOrderQueryArray } from "@/worker/utils";
 import { ERROR_TYPE, promise } from "@/common";
 
 export const executeWhereUndefinedLogic = function (this: Select) {
     let cursorRequest: IDBRequest;
-    if (this.query.order && this.query.order.idbSorting !== false && this.query.order.by) {
+    if (isNotOrderQueryArray(this.query.order) && this.query.order && this.query.order.idbSorting !== false && this.query.order.by) {
         if (this.objectStore.indexNames.contains(this.query.order.by as string)) {
             const orderType: IDBCursorDirection = this.query.order.type &&
                 this.query.order.type.toLowerCase() === 'desc' ? 'prev' : 'next';

--- a/src/worker/utils/index.ts
+++ b/src/worker/utils/index.ts
@@ -16,3 +16,4 @@ export * from "./get_error_from_exception";
 export * from "./set_cross_browser_idb";
 export * from "./resolve";
 export * from "./db_schema";
+export * from "./is_not_order_query_array";

--- a/src/worker/utils/is_not_order_query_array.ts
+++ b/src/worker/utils/is_not_order_query_array.ts
@@ -1,0 +1,5 @@
+import { IOrderQuery } from "@/common/interfaces";
+
+export const isNotOrderQueryArray = (value: IOrderQuery | IOrderQuery[]): value is IOrderQuery => {
+  return !Array.isArray(value);
+}


### PR DESCRIPTION
# Typescript typing issues fixed.
## desc
In typescript, cannot use array in select.order query because of typing issues.
## changed
- Added type `IOrderQuery[]` in `ISelectQuery.order`
- Changed construction methods of `Select` class by upper change.
- Added typeguard function `isNotOrderQueryArray` to utils.
## Testing 
Ubuntu LTS 20.04
Node.js v16.13.1
Finished in 11.183 secs / 10.628 secs @ 19:04:11 GMT+0900 (Korean Standard Time)

SUMMARY:
✔ 438 tests completed

