### PR TITLE
Update interfaces.ts to address keypath issue

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -125,7 +125,7 @@ export interface IWhereQueryOption {
 //     [columnName: string]: IWhereQueryOption | string | number | boolean;
 // }
 
-export type IWhereQuery = Record<string, IWhereQueryOption | string | number | boolean | Date> | { or?: IWhereQuery };
+export type IWhereQuery = Record<string, IWhereQueryOption | string | number | boolean | Date | any[]> | { or?: IWhereQuery };
 
 export interface ICaseOption {
     '>'?: any;


### PR DESCRIPTION
This PR solves #377 

According to the docs if we follow and create the table similar to 
https://jsstore.net/docs/keypath


it will give us type error for select query because of this 

```
connection.select({
    from: 'cities',
    where: {
        cityPincodes: ['london',12345] // order of values should be same as what has been defined in keyPath
    }
})
```

here the where is of type IWhereQuery or IWhereQuery[]

here is the problem 

the type `IWhereQuery `should include any[] as well to support the above select query

```
type IWhereQuery = Record<string, IWhereQueryOption | string | number | boolean | any[]> | {
    or?: IWhereQuery;
};

```