### PR TITLE
Ug feat handle versionchange event

### DIFF
--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -85,7 +85,8 @@ export enum EVENT {
     RequestQueueFilled = "requestQueueFilled",
     Upgrade = "upgrade",
     Create = "create",
-    Open = "open"
+    Open = "open",
+    DbRefreshRequired = "dbRefreshRequired",
 }
 
 export enum QUERY_OPTION {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,6 +13,7 @@ export type WebWorkerRequest = {
 export type WebWorkerResult = {
     error?: any;
     result?: any;
+    isDbClosedForcefully?: boolean;
 };
 
 

--- a/src/main/connection_helper.ts
+++ b/src/main/connection_helper.ts
@@ -83,6 +83,7 @@ export class ConnectionHelper {
       this.isDbClosedForcefully = true;
       this.requestQueue_ = [];
       console.warn('Database closed forcefully');
+      this.eventBus_.emit(EVENT.DbRefreshRequired, []);
       return;
     }
     const finishedRequest: WebWorkerRequest = this.requestQueue_.shift();

--- a/src/main/connection_helper.ts
+++ b/src/main/connection_helper.ts
@@ -76,8 +76,15 @@ export class ConnectionHelper {
     this.processFinishedQuery_(msg.data);
   }
 
-  private processFinishedQuery_(message: WebWorkerResult) {
+  private isDbClosedForcefully = false;
 
+  private processFinishedQuery_(message: WebWorkerResult) {
+    if (message.isDbClosedForcefully) {
+      this.isDbClosedForcefully = true;
+      this.requestQueue_ = [];
+      console.warn('Database closed forcefully');
+      return;
+    }
     const finishedRequest: WebWorkerRequest = this.requestQueue_.shift();
     if (finishedRequest) {
       this.logger.log(`request ${finishedRequest.name} finished`);
@@ -219,6 +226,7 @@ export class ConnectionHelper {
   }
 
   private prcoessExecutionOfQry_(request: WebWorkerRequest, index?: number) {
+    if (this.isDbClosedForcefully) return;
     this.isDbIdle_ = false;
     if (index != null) {
       this.requestQueue_.splice(index, 0, request);

--- a/src/worker/idbutil/index.ts
+++ b/src/worker/idbutil/index.ts
@@ -68,6 +68,8 @@ export class IDBUtil {
         });
     }
 
+    isDbClosedForcefully = false;
+
     initDb(db: DbMeta) {
         let isDbCreated = false;
         const dbVersion = db.version;
@@ -78,6 +80,7 @@ export class IDBUtil {
                 this.con = dbOpenRequest.result;
                 this.con.onversionchange = (e: any) => {
                     // if (e.newVersion === null) { // An attempt is made to delete the db
+                    this.isDbClosedForcefully = true;
                     e.target.close(); // Manually close our connection to the db
                     // }
                 }

--- a/src/worker/query_manager.ts
+++ b/src/worker/query_manager.ts
@@ -197,6 +197,13 @@ export class QueryManager {
     }
 
     run(request: WebWorkerRequest) {
+        if (this.util.isDbClosedForcefully) {
+            this.returnResult_({
+                error: new LogHelper(ERROR_TYPE.DbBlocked),
+                isDbClosedForcefully: true
+            });
+            return;
+        }
         let onResultCallback = [];
         const beforeExecuteCallback = [];
         request.onResult = (cb) => {
@@ -246,6 +253,7 @@ export class QueryManager {
         if (this.util) {
             this.util.emptyTx();
         }
+        result.isDbClosedForcefully = this.util.isDbClosedForcefully;
         this.onQryFinished(result);
     }
 


### PR DESCRIPTION
In case of database schema being updated in another tab or database being deleted. The active tab will be stuck or error thrown as db is being updated,

In this case an event is thrown to the user to allow them to refresh the current tab.