### PR TITLE
Ug fix update wait for tx

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -52,6 +52,7 @@ export interface IUpdateQuery {
     set: { [columnName: string]: any };
     where?: IWhereQuery | IWhereQuery[];
     mapSet?: string | Function;
+    returnImmediate?: boolean;
 }
 
 export interface IAlterQuery {

--- a/src/worker/executors/transaction/index.ts
+++ b/src/worker/executors/transaction/index.ts
@@ -164,6 +164,7 @@ export class Transaction extends Base {
         const query = request.query;
 
         const callAPI = (api: typeof Select) => {
+            query.returnImmediate = true;
             requestObj = new api(
                 query, this.util
             );

--- a/src/worker/executors/update/index.ts
+++ b/src/worker/executors/update/index.ts
@@ -1,4 +1,4 @@
-import { IUpdateQuery, ISelectQuery, QUERY_OPTION, API, IWhereQuery, DATA_TYPE, ERROR_TYPE } from "@/common";
+import { IUpdateQuery, ISelectQuery, QUERY_OPTION, API, IWhereQuery, DATA_TYPE, ERROR_TYPE, promiseAll } from "@/common";
 import { IDBUtil } from "@/worker/idbutil";
 import { DbMeta } from "@worker/model";
 import { QueryHelper } from "../query_helper";
@@ -15,6 +15,7 @@ export class Update extends BaseFetch {
 
     constructor(query: IUpdateQuery, util: IDBUtil) {
         super();
+        query.returnImmediate = query.returnImmediate == null ? true : query.returnImmediate;
         this.query = query as any;
         this.util = util;
         this.tableName = query.in;
@@ -37,7 +38,7 @@ export class Update extends BaseFetch {
             const err = queryHelper.validate(API.Update, query);
             if (err) return promiseReject(err);
             return beforeExecute().then(_ => {
-                this.initTransaction();
+                const txPromise = this.initTransaction();
                 let pResult: Promise<void>;
                 if (query.where != null) {
                     if ((query.where as IWhereQuery).or || isArray(query.where)) {
@@ -50,7 +51,11 @@ export class Update extends BaseFetch {
                 else {
                     pResult = this.executeWhereUndefinedLogic();
                 }
-                return pResult.then(() => {
+                const promiseToUse = [pResult];
+                if (query.returnImmediate === false && txPromise) {
+                    promiseToUse.push(txPromise);
+                }
+                return promiseAll(promiseToUse).then(() => {
                     return this.rowAffected;
                 })
             })
@@ -84,10 +89,12 @@ export class Update extends BaseFetch {
 
     private initTransaction() {
         const tableName = (this.query as any).in;
+        let promise: Promise<void>;
         if (!this.isTxQuery) {
-            this.util.createTransaction([tableName]);
+            promise = this.util.createTransaction([tableName]);
         }
         this.objectStore = this.util.objectStore(tableName);
+        return promise;
     }
 }
 

--- a/src/worker/executors/update/index.ts
+++ b/src/worker/executors/update/index.ts
@@ -1,6 +1,5 @@
 import { IUpdateQuery, ISelectQuery, QUERY_OPTION, API, IWhereQuery, DATA_TYPE, ERROR_TYPE, promiseAll } from "@/common";
 import { IDBUtil } from "@/worker/idbutil";
-import { DbMeta } from "@worker/model";
 import { QueryHelper } from "../query_helper";
 import { promiseReject, isArray, getDataType, variableFromPath, LogHelper } from "@worker/utils";
 import { BaseFetch } from "@executors/base_fetch";
@@ -15,7 +14,7 @@ export class Update extends BaseFetch {
 
     constructor(query: IUpdateQuery, util: IDBUtil) {
         super();
-        query.returnImmediate = query.returnImmediate == null ? true : query.returnImmediate;
+        query.returnImmediate = query.returnImmediate == null ? false : query.returnImmediate;
         this.query = query as any;
         this.util = util;
         this.tableName = query.in;

--- a/src/worker/idbutil/index.ts
+++ b/src/worker/idbutil/index.ts
@@ -27,7 +27,7 @@ export class IDBUtil {
 
     createTransaction(tables: string[], mode = IDB_MODE.ReadWrite) {
         this.tx = this.con.transaction(tables, mode);
-        return promise((res, rej) => {
+        return promise<void>((res, rej) => {
             this.tx.oncomplete = res;
             this.tx.onabort = res;
             this.tx.onerror = rej;


### PR DESCRIPTION
By default wait for transaction completion in case of update query - https://github.com/ujjwalguptaofficial/JsStore/issues

Add option - `returnImmediate` to allow users to control whether to return tx immediately or wait for tx completion.

